### PR TITLE
(fix) Correct acronym for AG's Office

### DIFF
--- a/acronyms.yml
+++ b/acronyms.yml
@@ -94,7 +94,7 @@
 - acronym: DExEU
   meaning: Department for Exiting the EU
 
-- acronym: AOG
+- acronym: AGO
   meaning: Attorney General’s Office
 
 - acronym: DVLA


### PR DESCRIPTION
This is the AGO, not the AOG: https://www.gov.uk/government/organisations/attorney-generals-office