### PR TITLE
Update the version of Haml to 5.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    haml (5.0.0)
+    haml (5.1.2)
       temple (>= 0.8.0)
       tilt
     slugify (1.0.7)
@@ -17,4 +17,4 @@ DEPENDENCIES
   tilt
 
 BUNDLED WITH
-   1.15.1
+   1.17.2


### PR DESCRIPTION
Haml 5.0.0 was a security fix that then broke the ability to build the
site. `uninitialized constant EXPR_ARG (NameError)` was the error. This
is fixed by updating to the latest version.
(https://github.com/haml/haml/issues/974)